### PR TITLE
Fix links for Chemfiles.jl

### DIFF
--- a/src/pages/documentation.html
+++ b/src/pages/documentation.html
@@ -59,9 +59,9 @@
         </div>
         <div class="col-lg-3">
             <ul>
-                <li><a href="/chemfiles.jl/latest/">Latest development version</a></li>
-                <li><a href="/chemfiles.jl/v0.10.0/">Stable version: 0.10.0</a></li>
-                <li><a href="/chemfiles.jl/v0.9.3/">Previous version: 0.9.3</a></li>
+                <li><a href="/Chemfiles.jl/latest/">Latest development version</a></li>
+                <li><a href="/Chemfiles.jl/v0.10.0/">Stable version: 0.10.0</a></li>
+                <li><a href="/Chemfiles.jl/v0.9.3/">Previous version: 0.9.3</a></li>
             </ul>
         </div>
         <div class="col-lg-3"></div>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -169,7 +169,7 @@
         <div class="col-md-6 mb-4">
             <figure>
                 <figcaption>Julia Pkg</figcaption>
-                <a href="https://github.com/chemfiles/chemfiles.jl">
+                <a href="https://github.com/chemfiles/Chemfiles.jl">
                     <img src="/static/images/logo-julia.svg" height=70px alt="Julia logo" />
                 </a>
             </figure>


### PR DESCRIPTION
It's a detail but the links to the documentation of the Julia version of chemfiles are broken on https://chemfiles.org/documentation.html because the Julia package is actually called "Chemfiles.jl" with a capital 'C'.
I also fixed the link to the github package, although it's not necessary since Github redirects https://github.com/chemfiles/chemfiles.jl to https://github.com/chemfiles/Chemfiles.jl